### PR TITLE
Support "git" package-type

### DIFF
--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -12,20 +12,32 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - name: Invoke action
-        id: self-test
+        with:
+          fetch-depth: 0
+      - id: self-test-npm
+        name: Invoke action
         uses: ./
         with:
           type: npm
           file: test/big-package.json
-      - name: Show outputs
+      - name: Show outputs for npm
         env:
-          OUTPUTS: ${{ toJson(steps.self-test.outputs) }}
+          OUTPUTS: ${{ toJson(steps.self-test-npm.outputs) }}
         run: |
           echo "${OUTPUTS}"
       - name: Assert results
         run: |
-          if test "${{ steps.self-test.outputs.version }}" != "1.2.3"; then
-            echo "Expected version 1.2.3, got ${{ steps.self-test.outputs.version }}!"
+          if test "${{ steps.self-test-npm.outputs.version }}" != "1.2.3"; then
+            echo "Expected version 1.2.3, got ${{ steps.self-test-npm.outputs.version }}!"
             exit 1
           fi
+      - id: self-test-git
+        name: Invoke action
+        uses: ./
+        with:
+          type: git
+      - name: Show outputs for git
+        env:
+          OUTPUTS: ${{ toJson(steps.self-test-git.outputs) }}
+        run: |
+          echo "${OUTPUTS}"

--- a/README.md
+++ b/README.md
@@ -3,11 +3,21 @@
 [![Self Test](https://github.com/infrastructure-blocks/package-version-action/actions/workflows/self-test.yml/badge.svg)](https://github.com/infrastructure-blocks/package-version-action/actions/workflows/self-test.yml)
 [![Update From Template](https://github.com/infrastructure-blocks/package-version-action/actions/workflows/update-from-template.yml/badge.svg)](https://github.com/infrastructure-blocks/package-version-action/actions/workflows/update-from-template.yml)
 
+This action extracts the version of a package. At the moment, it supports "npm" and "git" packages. It also
+supports overriding the default file where the version is extracted from, where it makes sense. 
+
+| Package Type | Default File | Supports Custom File | Description                                                                                                                                                                                                                                                               |
+|:------------:|:------------:|:--------------------:|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|     npm      | package.json |  :white_check_mark:  | The version is extracted from the `version` field of the `package.json` file.                                                                                                                                                                                             |
+|     git      |     N/A      |         :x:          | The version is extracted from the git tag. Only semantic versioning tags of the form `v<major>.<minor>.<patch>` are looked at. Note that it requires the git tags be available on the git tree. Make sure to call `actions/checkout` with `fetch-depth=0` prior to using. 
+|
+
+
 ## Inputs
 
 | Name | Required  | Description                                                                                                                                                |
 |:----:|:---------:|------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| type |   true    | The package type. Valid values include "npm".                                                                                                              |
+| type |   true    | The package type. Valid values include "npm", "git".                                                                                                       |
 | file |   false   | The package file. When not provided, it defaults to the standard file of the package type. For example, for type "npm", the default file is "package.json" |
 
 ## Outputs
@@ -22,6 +32,8 @@ N/A
 
 ## Usage
 
+### With NPM
+
 ```yaml
 jobs:
   do-stuff:
@@ -32,5 +44,22 @@ jobs:
         id: package-version
         with:
           type: npm
+      - run: echo "The current package version is ${{ steps.package-version.outputs.version }}" 
+```
+
+### With Git tags
+
+```yaml
+jobs:
+  do-stuff:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: infrastructure-blocks/package-version-action@v1
+        id: package-version
+        with:
+          type: git
       - run: echo "The current package version is ${{ steps.package-version.outputs.version }}" 
 ```

--- a/action.yml
+++ b/action.yml
@@ -23,22 +23,30 @@ runs:
           set -x
         fi
         
-        package_types=("npm")
+        package_types=("npm" "git")
         if test -z "$(echo ${package_types[@]} | fgrep -w "${{ inputs.type }}" )"; then
           echo "Invalid package type: ${{ inputs.type }}! Expected one of ${package_types[@]}."
           exit 1
         fi
         
         type="${{ inputs.type }}"
-        if test "$type" = "npm"; then
-          file="${{ inputs.file }}"
+        file="${{ inputs.file }}"
+        if test "${type}" = "npm"; then
           if test -z "${file}"; then
             file="package.json"
           fi
+        elif test "${type}" = "git"; then
+          if test -n "${file}"; then
+            echo "The git package type does not support custom files!"
+            exit 1
+          fi        
         fi
         
         echo "type=${type}" >> "${GITHUB_OUTPUT}"
-        echo "file=${file}" >> "${GITHUB_OUTPUT}"
+        
+        if test -n "${file}"; then
+          echo "file=${file}" >> "${GITHUB_OUTPUT}"
+        fi
     - id: get-current-version
       shell: bash
       run: |
@@ -48,4 +56,29 @@ runs:
         
         if test "${{ steps.parse-inputs.outputs.type }}" = "npm"; then
           echo "version=$(jq -r '.version' ${{ steps.parse-inputs.outputs.file }})" >> "${GITHUB_OUTPUT}"
+        elif test "${{ steps.parse-inputs.outputs.type }}" = "git"; then
+          commits_count=$(git rev-list --count HEAD)
+          if test "${commits_count}" = "1"; then
+            echo "This action requires to set fetch-depth: 0, but only found one commit on current branch!"
+            exit 1
+          fi
+        
+          # We look for the latest tag (using git version ordering) that matches the semver pattern, as found at https://semver.org/.
+          git_tags=$(git tag --sort=-v:refname)
+          if test -z "${git_tags}"; then
+            echo "No git tags found! Defaulting to 0.0.0."
+            version="0.0.0"
+          else
+            semver_git_tags=$(echo "${git_tags}" | grep -E '^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$')
+            if test -z "${semver_git_tags}"; then
+              echo "No semver git tags found! Defaulting to 0.0.0"
+              version="0.0.0"
+            else
+              latest_semver_git_tag=$(echo "${semver_git_tags}" | head -1)          
+              # We expect the git tags variants to be of the form `v<major>.<minor>.<patch>` however. So we strip out the `v` prefix.
+              version="${latest_semver_git_tag:1}"            
+            fi
+          fi
+        
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
         fi


### PR DESCRIPTION
- Works by parsing out semantic versioning tags and picking the
most highest according to git's version ordering and a semver
regexp.
- Should throw when package-file is provided.
- Closes #5
